### PR TITLE
RequireJS config fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
             {
                 "paths": {
                     "bootstrap-notify": "bootstrap-notify",
-                    "bootstrap-notify-min": "bootstrap-notify.min",
+                    "bootstrap-notify-min": "bootstrap-notify.min"
                 },
                 "shim": {
                     "bootstrap-notify": {


### PR DESCRIPTION
There was a needless comma in the config, that was rewarded by Play Webjars plugin with the following error message:

[error] 2016-10-16 12:32:42,883 o.w.RequireJS - Unexpected character ('}' (code 125)): was expecting either valid name character (for unquoted name) or double-quote (for quoted) to start field name
 at [Source: 
            {
                "paths": {
                    "bootstrap-notify": "bootstrap-notify",
                    "bootstrap-notify-min": "bootstrap-notify.min",
                },
                "shim": {
                    "bootstrap-notify": {
                        deps: ["jquery","bootstrap"],
                        exports: 'Notify'
                    }
                }
            }
        ; line: 6, column: 18]
